### PR TITLE
Add os.path.dirname(__file__) to the paths to find units.

### DIFF
--- a/creator/unit.py
+++ b/creator/unit.py
@@ -54,6 +54,7 @@ class Workspace(object):
   def __init__(self):
     super().__init__()
     self.path = ['.']
+    self.path.append(os.path.join(os.path.dirname(__file__)))
     self.path.append(os.path.join(os.path.dirname(__file__), 'builtins'))
     self.path.append(os.path.join(sys.prefix, 'creator'))
     self.path.extend(os.getenv('CREATORPATH', '').split(os.pathsep))


### PR DESCRIPTION
Adding the additional path fixes the
"creator.unit.UnitNotFoundError: platform" bug:

```
 $ creator program
 Traceback (most recent call last):
  File "/usr/local/bin/creator", line 4, in <module>
    __import__('pkg_resources').run_script('creator-build==0.0.3.dev0', 'creator')
  File "/home/wink/.local/lib/python3.4/site-packages/setuptools-18.0.1-py3.4.egg/pkg_resources/__init__.py", line 735, in run_script
  File "/home/wink/.local/lib/python3.4/site-packages/setuptools-18.0.1-py3.4.egg/pkg_resources/__init__.py", line 1652, in run_script
  File "/usr/local/lib/python3.4/dist-packages/creator_build-0.0.3.dev0-py3.4.egg/EGG-INFO/scripts/creator", line 25, in <module>
    sys.exit(creator.__main__.main())
  File "/usr/local/lib/python3.4/dist-packages/creator_build-0.0.3.dev0-py3.4.egg/creator/__main__.py", line 124, in main
    unit = workspace.load_unit(args.unit)
  File "/usr/local/lib/python3.4/dist-packages/creator_build-0.0.3.dev0-py3.4.egg/creator/unit.py", line 137, in load_unit
    unit.run_unit_script(filename)
  File "/usr/local/lib/python3.4/dist-packages/creator_build-0.0.3.dev0-py3.4.egg/creator/unit.py", line 276, in run_unit_script
    exec(code, self.scope)
  File "/home/wink/prgs/test-creator/hello.crunit", line 1, in <module>
    load('platform', 'p')
  File "/usr/local/lib/python3.4/dist-packages/creator_build-0.0.3.dev0-py3.4.egg/creator/unit.py", line 443, in load
    unit = self.workspace.load_unit(identifier)
  File "/usr/local/lib/python3.4/dist-packages/creator_build-0.0.3.dev0-py3.4.egg/creator/unit.py", line 132, in load_unit
    filename = self.find_unit(identifier)
  File "/usr/local/lib/python3.4/dist-packages/creator_build-0.0.3.dev0-py3.4.egg/creator/unit.py", line 113, in find_unit
    raise UnitNotFoundError(identifier)
 creator.unit.UnitNotFoundError: platform
```