### PR TITLE
Fix setup.py so the builtins/*.crunit files are installed properly.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,7 @@ setuptools.setup(
   py_modules=['creator'],
   packages=setuptools.find_packages('.'),
   package_dir={'': '.'},
-  data_files=[
-    ('creator', glob.glob('creator/builtins/*.crunit')),
-  ],
+  package_data={ 'creator': ['builtins/*.crunit'] },
   scripts=['scripts/creator'],
   classifiers=[
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
When installing via "sudo pip3 install ." the data_files parameter caused
the crunit files to be placed in /usr/local/creator/. By using package_data
they are now placed in the python's {...}/dist-packages/creator/ directory
which is where where the unit.py/find_unit routine is looking for them.